### PR TITLE
Export can-observe Object and Array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist/
+doc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 dist/
-doc
+doc/

--- a/ylem.js
+++ b/ylem.js
@@ -1,4 +1,5 @@
 import namespace from 'can-namespace';
+import { Object, Array } from 'can-observe';
 
 import connect from './connect';
 const withViewModel = connect;
@@ -11,4 +12,6 @@ namespace.reactViewModel = {
 export {
 	connect,
 	withViewModel,
+	Object,
+	Array,
 };


### PR DESCRIPTION
Also, ignore the `doc` folder to prevent the accidental publishing of the `GREADME`