### PR TITLE
Fix the main import and export to work with build and also have default export

### DIFF
--- a/ylem.js
+++ b/ylem.js
@@ -1,24 +1,27 @@
 import namespace from 'can-namespace';
-import { Object, Array } from 'can-observe';
+import observe from 'can-observe';
 
 import connect from './connect';
 import Component from './component';
 import createViewModelComponent from './create-view-model-component';
 
-namespace.reactViewModel = {
+const { Obect: ViewModel, Array: ModelList } = observe;
+
+namespace.ylem = {
 	connect,
 	withViewModel: connect,
 	Component,
-	Object,
-	Array,
+	ViewModel,
+	ModelList,
 	createViewModelComponent,
 };
 
+export default namespace.ylem;
 export {
 	connect,
 	connect as withViewModel,
 	Component,
-	Object,
-	Array,
+	ViewModel,
+	ModelList,
 	createViewModelComponent,
 };


### PR DESCRIPTION
This is a crucial fix - it does several things:

- Fixes the build by using `import observe from 'can-observe'` instead of named imports.
- Adds a default export so that someone can do `ylem.Component`
- Aliases `observe.Object` and `observe.Array` to `ViewModel` and `ModelList` named exports respecively (based on conversation with @christopherjbaker 

