### PR TITLE
Split repo into two parts for usability testing

### DIFF
--- a/component/README.md
+++ b/component/README.md
@@ -1,0 +1,83 @@
+# ylem - Easy state management for React
+
+[![Build Status](https://travis-ci.org/bitovi/ylem.svg?branch=master)](https://travis-ci.org/bitovi/ylem)
+[![Greenkeeper Badge](https://badges.greenkeeper.io/bitovi/ylem.svg)](https://greenkeeper.io/)
+
+**ylem** provides fast and easy state management for your [React](https://reactjs.org) application by using [observable objects](https://canjs.com/doc/can-observe.html). Simply update your state objects whenever/however you want and your app will be re-rendered as efficiently as possible.
+
+## Getting Started
+
+```
+npm install ylem --save
+```
+
+* [Configure with Webpack](./docs/getting-started-webpack.md)
+* [Configure with StealJS](./docs/getting-started-steal.md)
+
+## Usage
+
+**If you know React and JavaScript, you already know ylem.** The following is a basic example of how to update state using **ylem**. Feel free to edit this example on [CodeSandbox](https://codesandbox.io/s/qx1nzj6r29?hidenavigation=1&module=%2Fsrc%2Fylem%2Fhello-world.js&moduleview=1).
+
+1. **Step 1:** Extend **ylem's** `Component` instead of `React.Component`:
+
+    ```js
+    import React from 'react';
+    import { Component } from 'ylem';
+    
+    class HelloWorld extends Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          name: 'Justin'
+        };
+      }
+      render() {
+        return (
+          <div>
+          	Hello {this.state.name}!
+          </div>
+        );
+      }
+    }
+    ```
+
+2. **Step 2:** update state directly! Continuing with the last example, notice how you can update state directly:
+
+    ```js
+    import React from 'react';
+    import { Component } from 'ylem';
+    
+    class HelloWorld extends Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          name: 'Justin'
+        };
+      }
+      
+      updateName = (ev) => {
+        // no need to call this.setState();
+        this.state.name = ev.target.value;
+      }
+      
+      render() {
+        return (
+          <div>
+          	Hello {this.state.name}!
+          	<div>
+          	  <input onChange={this.updateName} />
+          	</div>
+          </div>
+        );
+      }
+    }
+    ```
+
+Notice that instead of calling `.setState`, we were able to just set the `.name` property directly? We know [React tells you not to do this](https://reactjs.org/docs/state-and-lifecycle.html#do-not-modify-state-directly), but now you _can_ update state directly with **ylem**. This seemingly minor change has all sorts of benefits - read more about it on the [ylem homepage](http://bitovi.github.io/ylem).
+
+
+## Contributing
+Read the [contributing guides](./contributing.md)
+
+## License
+[MIT](./LICENSE.md) License

--- a/component/component.js
+++ b/component/component.js
@@ -1,8 +1,10 @@
 import observe from 'can-observe';
 import canReflect from 'can-reflect';
-import ObservableComponent from './observable-component';
+import ObservableComponent from '../observable-component';
 
+//!steal-remove-start
 import ReactDOM from 'react-dom';
+//!steal-remove-end
 
 const gdsfp = Symbol.for('ylem.component.gdsfp');
 

--- a/component/docs/getting-started-steal.md
+++ b/component/docs/getting-started-steal.md
@@ -1,0 +1,76 @@
+## Getting Started with NPM and StealJS
+
+To use **ylem** with NPM and StealJS, simply install the steal suite, react, and ylem.
+
+```sh
+npm install steal steal-tools done-serve --save-dev
+npm install react react-dom ylem --save
+```
+
+You will need to add a `steal` section to your `package.json`. We recommend using the `transform-class-properties` babel plugin to enable simpler callbacks and PropTypes. To simplify your development cycle, we have also included two scripts below.
+
+```json
+{
+  "main": "index.js",
+  "scripts": {
+    "develop": "done-serve --develop",
+    "build": "steal-tools build"
+  },
+  "steal": {
+    "babelOptions": {
+      "plugins": [
+        "transform-class-properties"
+      ]
+    }
+  }
+}
+```
+
+You will also need an `index.html` to load in the browser.
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ylem Demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="node_modules/steal/steal.js"></script>
+  </body>
+</html>
+```
+
+From here, you need only create your `index.js`, run `npm run develop`, and open it in your browser (http://localhost:8080).
+
+```js
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Component } from 'ylem';
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { user: null };
+  }
+
+  login = () => {
+    this.state.user = { name: 'yetti' };
+  }
+
+  render() {
+    return (
+      <div>
+        <button onClick={this.login}>Login</button>
+        {this.state.user && 
+          <div>Welcome {this.state.user.name}!</div>
+        }
+      </div>
+    )
+  }
+}
+
+ReactDOM.render(<App />, document.getElementById('app'));
+```
+
+Want to learn more about StealJS? [Check out the docs!](https://stealjs.com/docs/)

--- a/component/docs/getting-started-webpack.md
+++ b/component/docs/getting-started-webpack.md
@@ -1,0 +1,54 @@
+## Getting Started with NPM and Webpack
+
+The best way to get **ylem** started with Webpack and React is with [Create React App](https://github.com/facebook/create-react-app). First make sure you have `npx` installed globally:
+
+```sh
+npm install npx -g
+```
+
+Next, generate your react app - we are calling it `my-app`:
+
+```sh
+npx create-react-app my-app
+cd my-app
+```
+
+Finally, install ylem and start your app:
+
+```
+npm install ylem --save
+npm start
+```
+
+From here, you can modify `src/App.js` to use the **ylem** `Component` and see the live-reload in the browser.
+
+```js
+import React from 'react';
+import logo from './logo.svg';
+import './App.css';
+import { Component } from 'ylem';
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { user: null };
+  }
+
+  login = () => {
+    this.state.user = { name: 'yetti' };
+  }
+
+  render() {
+    return (
+      <div>
+        <button onClick={this.login}>Login</button>
+        {this.state.user && 
+          <div>Welcome {this.state.user.name}!</div>
+        }
+      </div>
+    )
+  }
+}
+
+export default App;
+```

--- a/connect/README.md
+++ b/connect/README.md
@@ -1,0 +1,88 @@
+# ylem - Easy state management for React
+
+[![Build Status](https://travis-ci.org/bitovi/ylem.svg?branch=master)](https://travis-ci.org/bitovi/ylem)
+[![Greenkeeper Badge](https://badges.greenkeeper.io/bitovi/ylem.svg)](https://greenkeeper.io/)
+
+**ylem** provides fast and easy state management for your [React](https://reactjs.org) application by using [observable objects](https://canjs.com/doc/can-observe.html). Simply update your state objects whenever/however you want and your app will be re-rendered as efficiently as possible.
+
+## Getting Started
+
+```
+npm install ylem --save
+```
+
+* [Configure with Webpack](./docs/getting-started-webpack.md)
+* [Configure with StealJS](./docs/getting-started-steal.md)
+
+## Usage
+
+### Step 1 - Create observable stores using ObserveObject
+
+The recommended way for creating observable stores is to create a class which extends `ObserveObject`:
+
+```js
+// Store.js
+import { ObserveObject } from 'ylem';
+
+class Store extends ObserveObject {
+	count = 0
+	
+	increment = () => {
+	  this.count++;
+	}
+}
+
+export default Store;
+```
+
+### Step 2 - Connect your Store to your Component
+
+Similar to redux, **ylem** is all about connecting data stores to presentation components. Once connected, **ylem** will automatically pass an instance of the store to your component as props:
+
+```js
+// Counter.js
+import React from 'react';
+import ylem from 'ylem';
+import Store from './store';
+
+const Counter = (props) => (
+   // props is an instance of your Store class
+	<div onClick={props.increment}>{props.count}</div>
+);
+
+// Use ylem to connect your Store to your Component
+export default ylem(Store, Counter);
+```
+
+### Step 3 - Render your component!
+
+In the following example, **ylem** will render the Counter component with a starting count of `99`:
+
+```js
+import React, Component from 'react';
+import { ObserveObject } from 'ylem';
+import Counter from './counter';
+
+class AppState extends ObserveObject {
+  startingCount = 99
+};
+
+class App extends React.Component {
+  render() {
+    return (
+      <div>
+        <h1>Welcome to my Counter app</h1>
+        <Counter count={this.props.startingCount} />
+      </div>
+    );
+  }
+};
+
+export default ylem(AppState, App)
+```
+
+## Contributing
+Read the [contributing guides](./contributing.md)
+
+## License
+[MIT](./LICENSE.md) License

--- a/connect/connect.js
+++ b/connect/connect.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import canReflect from 'can-reflect';
-import { createNewComponentClass, getConnectedComponent } from './observable-component';
+import { createNewComponentClass, getConnectedComponent } from '../observable-component';
 
 //!steal-remove-start
 (function(version) {

--- a/connect/docs/getting-started-steal.md
+++ b/connect/docs/getting-started-steal.md
@@ -46,29 +46,26 @@ From here, you need only create your `index.js`, run `npm run develop`, and open
 ```js
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ylem from 'ylem';
+import ylem, { ObserveObject } from 'ylem';
 
-class Counter extends ylem.Component {
-  constructor(props) {
-    super(props);
-    this.state = { count: 0 };
-  }
-
-  increment = () => {
-    this.state.count++;
-  }
-
-  render() {
-    return (
-      <div>
-        Count: {this.state.count}<br />
-        <button onClick={this.increment}>+1</button>
-      </div>
-    )
-  }
+class AppState extends ObserveObject {
+    user = null
+    
+    login = () => {
+        this.user = { name: 'yetti' };
+    }
 }
 
-ReactDOM.render(<Counter />, document.getElementById('app'));
+const App = ylem(AppState, (props) => (
+    <div>
+    	<button onClick={props.login}>Login</button>
+    	{props.user && 
+    		<div>Welcome {props.user.name}!</div>
+    	}
+    </div>
+));
+
+ReactDOM.render(<App />, document.getElementById('app'));
 ```
 
 Want to learn more about StealJS? [Check out the docs!](https://stealjs.com/docs/)

--- a/connect/docs/getting-started-webpack.md
+++ b/connect/docs/getting-started-webpack.md
@@ -26,32 +26,24 @@ From here, you can modify `src/App.js` to use the **ylem** `Component` and see t
 import React from 'react';
 import logo from './logo.svg';
 import './App.css';
-import { Component } from 'ylem';
+import ylem, { ObserveObject } from 'ylem';
 
-class App extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { count: 0 };
-  }
-
-  increment = () => {
-    this.state.count++;
-  }
-
-  render() {
-    return (
-      <div className="App">
-        <header className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <p>
-            Count: {this.state.count}
-          </p>
-          <a className="App-link" onClick={this.increment}>+1</a>
-        </header>
-      </div>
-    );
-  }
+class AppState extends ObserveObject {
+    user = null
+    
+    login = () => {
+        this.user = { name: 'yetti' };
+    }
 }
+
+const App = ylem(AppState, (props) => (
+    <div>
+    	<button onClick={props.login}>Login</button>
+    	{props.user && 
+    		<div>Welcome {props.user.name}!</div>
+    	}
+    </div>
+));
 
 export default App;
 ```

--- a/readme.md
+++ b/readme.md
@@ -4,84 +4,15 @@
 [![Greenkeeper Badge](https://badges.greenkeeper.io/bitovi/ylem.svg)](https://greenkeeper.io/)
 
 > [ahy-luh m] *noun* `ASTRONOMY`
->   
+>
 > The primordial matter of the universe from which all matter is said to be derived, believed to be composed of neutrons at high temperature and density.
 
-**ylem** provides fast and easy state management for your [React](https://reactjs.org) application by using [observable objects](https://canjs.com/doc/can-observe.html). Simply update your state objects whenever/however you want and your app will be re-rendered as efficiently as possible.
+## QA mode
 
-## Getting Started
+**ylem** uses observable objects to determine when to re-render components. We are currently considering two APIs - each has its own README and docs:
 
-```
-npm install ylem --save
-```
-
-* [Configure with Webpack](./docs/getting-started-webpack.md)
-* [Configure with StealJS](./docs/getting-started-steal.md)
-
-## Usage
-
-**If you know React and JavaScript, you already know ylem.** The following is a basic example of how to update state using **ylem**. Feel free to edit this example on [CodeSandbox](https://codesandbox.io/s/qx1nzj6r29?hidenavigation=1&module=%2Fsrc%2Fylem%2Fhello-world.js&moduleview=1).
-
-1. **Step 1:** Extend **ylem's** `Component` instead of `React.Component`:
-
-    ```js
-    import React from 'react';
-    import { Component } from 'ylem';
+1. Extend ylem's **`Component`** - `this.state` is observable, no more `.setState()`.  
+    [Read more here](./component).
     
-    class HelloWorld extends Component {
-      constructor(props) {
-        super(props);
-        this.state = {
-          name: 'Justin'
-        };
-      }
-      render() {
-        return (
-          <div>
-          	Hello {this.state.name}!
-          </div>
-        );
-      }
-    }
-    ```
-
-2. **Step 2:** update state directly! Continuing with the last example, notice how you can update state directly:
-
-    ```js
-    import React from 'react';
-    import { Component } from 'ylem';
-    
-    class HelloWorld extends Component {
-      constructor(props) {
-        super(props);
-        this.state = {
-          name: 'Justin'
-        };
-      }
-      
-      updateName = (ev) => {
-        // no need to call this.setState();
-        this.state.name = ev.target.value;
-      }
-      
-      render() {
-        return (
-          <div>
-          	Hello {this.state.name}!
-          	<div>
-          	  <input onChange={this.updateName} />
-          	</div>
-          </div>
-        );
-      }
-    }
-    ```
-
-Notice that instead of calling `.setState`, we were able to just set the `.name` property directly? We know [React tells you not to do this](https://reactjs.org/docs/state-and-lifecycle.html#do-not-modify-state-directly), but now you _can_ update state directly with **ylem**. This seemingly minor change has all sorts of benefits - read more about it on the [ylem homepage](http://bitovi.github.io/ylem).
-
-
-## Contributing
-Read the [contributing guides](./contributing.md)
-
-## License
-[MIT](./LICENSE.md) License
+2. **`connect()`** - connect an observable object to a presentation (aka. "dumb") component (similar to redux).  
+    [Read more here](./connect).

--- a/ylem.js
+++ b/ylem.js
@@ -1,8 +1,8 @@
 import namespace from 'can-namespace';
 import { Object as ObserveObject, Array as ObserveArray} from 'can-observe';
 
-import connect from './connect';
-import Component from './component';
+import connect from './connect/connect';
+import Component from './component/component';
 import createViewModelComponent from './create-view-model-component';
 
 namespace.ylem = {


### PR DESCRIPTION
This splits the repo into 2 directories - 1) component and 2) connect - representing the "easy" vs. "maintainable" APIs respectively. This is a temporary move while we do usability testing on the two different versions.