### PR TITLE
Update for react 16.4

### DIFF
--- a/lib/observable-component.js
+++ b/lib/observable-component.js
@@ -8,51 +8,67 @@ class ObservableComponent extends ObserverComponent {
 	static ObservableClass = ObservableClass
 	static mapProps = p => p
 
-	constructor(props) {
-		super(props);
-		if (this.props.component || this.props.Component) {
-			this.Component = createObservablePropsComponent(this.props.component || this.props.Component);
+	static getDerivedStateFromProps(nextProps, { observer, observable, mapProps, lastProps }) {
+		if (!observable || nextProps === lastProps) {
+			return null;
 		}
-		this.observable = new this.constructor.ObservableClass();
 
-		this.state = {
-			observable: this.observable,
-			observer: this.observer,
-			mapProps: this.constructor.mapProps
+		updateObservableWithProps(observable, mapProps(nextProps), observer);
+
+		return {
+			lastProps: nextProps,
 		};
 	}
 
-	static getDerivedStateFromProps(nextProps, {observer, observable, mapProps}) {
-		if (!observable) return;
-		updateObservableWithProps(observable, mapProps(nextProps), observer);
-		return null;
-	}
+	constructor(props) {
+		super(props);
 
-	render() {
-		const { Component, observable, props: { render, children } } = this;
-		if (render) {
-			return render(observable);
+		if (this.props.component || this.props.Component) {
+			this.Component = createObservablePropsComponent(this.props.component || this.props.Component);
 		}
-		if (Component) {
-			return <Component _observable={observable} />;
-		}
-		if (typeof children === 'function') {
-			return children(observable);
-		}
-		return children;
+
+		this.state = {
+			observable: new this.constructor.ObservableClass(),
+			observer: this.observer,
+			mapProps: this.constructor.mapProps,
+		};
 	}
 
 	componentWillUnmount() {
 		super.componentWillUnmount();
+
 		if (this.observable && this.observable.stopListening) {
 			this.observable.stopListening();
 		}
+	}
+
+	get observable() {
+		return this.state.observable;
+	}
+
+	render() {
+		const { Component, observable, props: { render, children } } = this;
+
+		if (render) {
+			return render(observable);
+		}
+
+		if (Component) {
+			return <Component _observable={observable} />;
+		}
+
+		if (typeof children === 'function') {
+			return children(observable);
+		}
+
+		return children;
 	}
 }
 
 function updateObservableWithProps(observable, newProps, observer) {
 	observer.ignore(() => {
 		const { render, component, Component, ...props } = newProps; // eslint-disable-line no-unused-vars
+
 		if (Array.isArray(props.children)) {
 			// `.children` is non-extensible
 			props.children = [ ...props.children ];
@@ -64,6 +80,7 @@ function updateObservableWithProps(observable, newProps, observer) {
 			// idea would be to merge array, but replace items
 			delete observable.children;
 		}
+
 		canReflect.assignDeep(observable, props);
 	});
 }

--- a/package.json
+++ b/package.json
@@ -68,15 +68,15 @@
     "eslint": "^4.19.1",
     "eslint-plugin-react": "^7.8.0",
     "prop-types": "^15.6.1",
-    "react": "~16.3.2",
-    "react-dom": "~16.3.2",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "steal": "^1.11.6",
     "steal-qunit": "^1.0.1",
     "steal-tools": "^1.11.8",
     "testee": "^0.8.0"
   },
   "peerDependencies": {
-    "react": "~16.3.2"
+    "react": "^16.3.2"
   },
   "steal": {
     "main": "index",

--- a/test/connect.js
+++ b/test/connect.js
@@ -266,9 +266,8 @@ QUnit.module('@connect with ObserveObject', () => {
 		assert.equal(divComponent.innerText, 'foobar', 'rendered component has the correct contents');
 	});
 
-	QUnit.skip('should update parent before child', (assert) => {
-		// var expected = [ 'parent', 'child1', 'child2', 'parent', 'child1', 'child2' ];
-		var expected = [ 'parent', 'child1', 'child2', 'parent', 'parent', 'child1', 'parent', 'child2' ];
+	QUnit.test('should update parent before child', (assert) => {
+		let parent = false;
 
 		@connect(EmptyViewModel)
 		class ChildComponent1 extends Component {
@@ -279,7 +278,7 @@ QUnit.module('@connect with ObserveObject', () => {
 			}
 
 			render() {
-				assert.equal('child1', expected.shift(), 'child1 renderer called in the right order');
+				assert.equal(parent, true, 'parent rendered before child1');
 
 				const { name } = this.props;
 				return <div>{name.first}</div>;
@@ -295,7 +294,7 @@ QUnit.module('@connect with ObserveObject', () => {
 			}
 
 			render() {
-				assert.equal('child2', expected.shift(), 'child2 renderer called in the right order');
+				assert.equal(parent, true, 'parent rendered before child2');
 
 				const { name } = this.props;
 				return <div>{name.first}</div>;
@@ -311,7 +310,7 @@ QUnit.module('@connect with ObserveObject', () => {
 			}
 
 			render() {
-				assert.equal('parent', expected.shift(), 'parent renderer called in the right order');
+				parent = true;
 
 				const { name } = this.props;
 				return (
@@ -325,9 +324,9 @@ QUnit.module('@connect with ObserveObject', () => {
 		}
 
 		const observable = ReactTestUtils.renderIntoDocument( <ParentComponent name={{ first: 'Yetti' }} /> ).observable;
-		observable.name.first = 'Christopher';
 
-		assert.equal(expected.length, 0, 'all expectations were run');
+		parent = false;
+		observable.name.first = 'Christopher';
 	});
 
 	QUnit.test('should change props on the correct children - deep tree', (assert) => {


### PR DESCRIPTION
In 16.3, react only calls `getDerivedStateFromProps` when props have changed. In 16.4, it is called on every render. This being how we get new info to put into the observable, the extra updates were causing extra renders, sometimes recursively. This checks the incoming props against the last props and skips the update if props has not changed.

This PR also fixes one of the tests we had written before but set to skip, as it was testing implementation details not the actual problem (of children rendering before parents).